### PR TITLE
Color generator tweaks

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -12,7 +12,7 @@ fn next_colorous_color() -> colorous::Color {
 
 fn next_color_index() -> usize {
     static COUNTER: sync::atomic::AtomicUsize = sync::atomic::AtomicUsize::new(0);
-    COUNTER.fetch_add(1, sync::atomic::Ordering::AcqRel) % COLORS.len()
+    COUNTER.fetch_add(1, sync::atomic::Ordering::Relaxed) % COLORS.len()
 }
 
 fn colorous_color_to_pathfinder_color(c: colorous::Color) -> pathfinder_canvas::ColorU {

--- a/src/color.rs
+++ b/src/color.rs
@@ -2,10 +2,6 @@ use std::sync;
 
 const COLORS: [colorous::Color; 10] = colorous::CATEGORY10;
 
-lazy_static::lazy_static! {
-    static ref COLOR_INDEX: sync::atomic::AtomicUsize = sync::atomic::AtomicUsize::new(0);
-}
-
 pub fn next() -> pathfinder_canvas::ColorU {
     colorous_color_to_pathfinder_color(next_colorous_color())
 }
@@ -15,7 +11,8 @@ fn next_colorous_color() -> colorous::Color {
 }
 
 fn next_color_index() -> usize {
-    COLOR_INDEX.fetch_add(1, sync::atomic::Ordering::AcqRel) % COLORS.len()
+    static COUNTER: sync::atomic::AtomicUsize = sync::atomic::AtomicUsize::new(0);
+    COUNTER.fetch_add(1, sync::atomic::Ordering::AcqRel) % COLORS.len()
 }
 
 fn colorous_color_to_pathfinder_color(c: colorous::Color) -> pathfinder_canvas::ColorU {


### PR DESCRIPTION
Two commits:

- There's no need to put an AtomicUsize inside lazy_static. It can be an ordinary static.
- Change AcqRel to Relaxed ordering. All this code needs is for the counter to be incremented atomically. It isn't using the write or read of the counter to coordinate any subsequent or previous memory operations with other threads.