### PR TITLE
fix typo in "source" label

### DIFF
--- a/rgis-ui/src/lib.rs
+++ b/rgis-ui/src/lib.rs
@@ -53,7 +53,7 @@ fn render_mouse_position_window(ui: &mut egui::Ui, ui_state: &UiState) {
         let mut unprojected = ui_state.projected_mouse_position.clone();
         unprojected.reproject(&ui_state.source_srs);
 
-        ui.label(format!("Source SRS: {}", ui_state.target_srs));
+        ui.label(format!("Source SRS: {}", ui_state.source_srs));
         egui::Frame::group(ui.style()).show(ui, |ui| {
             ui.label(format!("X: {}", unprojected.coord.x));
             ui.label(format!("Y: {}", unprojected.coord.y));


### PR DESCRIPTION
Previously `source` was incorrectly using the `target` SRS

**before**
<img width="187" alt="Screen Shot 2021-04-21 at 7 50 53 AM" src="https://user-images.githubusercontent.com/217057/115574534-9257cb80-a276-11eb-877d-dd530ba5f154.png">

**after**
<img width="209" alt="Screen Shot 2021-04-21 at 7 50 26 AM" src="https://user-images.githubusercontent.com/217057/115574538-92f06200-a276-11eb-985b-3f951b126fb9.png">
