### PR TITLE
Fix an issue to disable Move down button for last (bottom) layer

### DIFF
--- a/rgis-ui/src/side_panel.rs
+++ b/rgis-ui/src/side_panel.rs
@@ -58,7 +58,7 @@ impl<'a, 'w, 's> SidePanel<'a, 'w, 's> {
 
     fn render_layers(&mut self, ui: &mut egui::Ui) {
         for (i, layer) in self.layers.iter_top_to_bottom().enumerate() {
-            self.render_layer(ui, layer, i > 0, i < self.layers.count());
+            self.render_layer(ui, layer, i > 0, i < self.layers.count() - 1);
         }
     }
 


### PR DESCRIPTION
Move down was enabled for last bottom layer caused by incorrect bounds comparison