### PR TITLE
Fix underflow panic and improve event handling for layers order

### DIFF
--- a/rgis-layers/src/systems.rs
+++ b/rgis-layers/src/systems.rs
@@ -67,23 +67,36 @@ fn handle_move_layer_events(
         };
 
         let new_z_index = match event.1 {
-            rgis_events::MoveDirection::Up => old_z_index + 1,
-            rgis_events::MoveDirection::Down => old_z_index - 1,
-        };
-
-        let other_layer_id = match layers.data.get(new_z_index) {
-            Some(layer) => layer.id,
-            None => {
-                bevy::log::warn!("Could not find layer");
-                continue;
+            rgis_events::MoveDirection::Up => {
+                if old_z_index < layers.count() - 1 {
+                    old_z_index + 1
+                } else {
+                    old_z_index
+                }
+            }
+            rgis_events::MoveDirection::Down => {
+                if old_z_index > 0 {
+                    old_z_index - 1
+                } else {
+                    old_z_index
+                }
             }
         };
+        if new_z_index != old_z_index {
+            let other_layer_id = match layers.data.get(new_z_index) {
+                Some(layer) => layer.id,
+                None => {
+                    bevy::log::warn!("Could not find layer");
+                    continue;
+                }
+            };
 
-        layers.data.swap(old_z_index, new_z_index);
+            layers.data.swap(old_z_index, new_z_index);
 
-        layer_z_index_updated_event_writer.send(rgis_events::LayerZIndexUpdatedEvent(event.0));
-        layer_z_index_updated_event_writer
-            .send(rgis_events::LayerZIndexUpdatedEvent(other_layer_id));
+            layer_z_index_updated_event_writer.send(rgis_events::LayerZIndexUpdatedEvent(event.0));
+            layer_z_index_updated_event_writer
+                .send(rgis_events::LayerZIndexUpdatedEvent(other_layer_id));
+        }
     }
 }
 


### PR DESCRIPTION
- Fix invalid z-index for top and bottom layers on handling move up/down events (causing underflow panic)
- Avoid sending unnecessary z-index change events when not changed