### PR TITLE
Fix NaN-land when zooming out too far

### DIFF
--- a/rgis-camera/src/systems.rs
+++ b/rgis-camera/src/systems.rs
@@ -81,7 +81,9 @@ fn zoom_camera_system(
     for event in zoom_camera_event_reader.iter() {
         camera_scale.zoom(event.amount);
     }
-    crate::utils::set_camera_transform(&mut transform, camera_offset, camera_scale);
+    if camera_scale.0.is_finite() {
+        crate::utils::set_camera_transform(&mut transform, camera_offset, camera_scale);
+    }
 }
 
 fn handle_meshes_spawned_events(


### PR DESCRIPTION
Fixes #70
Skip zoom event when it causes infinite value for camera scale