### PR TITLE
feat: Implement thick lines for line renderer

### DIFF
--- a/rgis-layer-events/src/lib.rs
+++ b/rgis-layer-events/src/lib.rs
@@ -50,6 +50,9 @@ pub struct LayerReprojectedEvent(pub rgis_primitives::LayerId);
 #[derive(Event, Debug)]
 pub struct DuplicateLayerEvent(pub rgis_primitives::LayerId);
 
+#[derive(Event, Debug)]
+pub struct LayerStrokeWidthUpdatedEvent(pub rgis_primitives::LayerId, pub f32);
+
 pub struct Plugin;
 
 impl bevy::app::Plugin for Plugin {
@@ -60,6 +63,7 @@ impl bevy::app::Plugin for Plugin {
             .add_event::<LayerBecameVisibleEvent>()
             .add_event::<LayerColorUpdatedEvent>()
             .add_event::<LayerPointSizeUpdatedEvent>()
+            .add_event::<LayerStrokeWidthUpdatedEvent>()
             .add_event::<DeleteLayerEvent>()
             .add_event::<MoveLayerEvent>()
             .add_event::<LayerZIndexUpdatedEvent>()

--- a/rgis-layers/src/lib.rs
+++ b/rgis-layers/src/lib.rs
@@ -175,6 +175,7 @@ impl Layers {
             crs,
             geom_type,
             point_size: 5.0,
+            stroke_width: 1.0,
         };
         self.data.push(layer);
         layer_id
@@ -210,6 +211,7 @@ pub struct Layer {
     pub crs: rgis_primitives::Crs,
     pub geom_type: geo_geom_type::GeomType,
     pub point_size: f32,
+    pub stroke_width: f32,
 }
 
 impl Layer {

--- a/rgis-renderer/src/fill_helper.rs
+++ b/rgis-renderer/src/fill_helper.rs
@@ -1,0 +1,26 @@
+use bevy::{ecs::relationship::RelatedSpawnerCommands, prelude::*};
+
+use crate::{Fill, RenderEntityType, ZIndex};
+
+pub fn spawn_fill_helper(
+    materials: &mut Assets<ColorMaterial>,
+    color: Color,
+    layer_index: crate::rgis_layers::LayerIndex,
+    mesh: Mesh,
+    commands: &mut RelatedSpawnerCommands,
+    assets_meshes: &mut Assets<Mesh>,
+    entity_type: RenderEntityType,
+) {
+    let material = materials.add(color);
+    let z_index = ZIndex::calculate(layer_index, entity_type);
+    commands.spawn((
+        MeshBundle {
+            mesh: assets_meshes.add(mesh),
+            transform: Transform::from_xyz(0., 0., z_index.0 as f32),
+            material,
+            ..Default::default()
+        },
+        entity_type,
+        Fill,
+    ));
+}

--- a/rgis-renderer/src/jobs.rs
+++ b/rgis-renderer/src/jobs.rs
@@ -4,21 +4,23 @@ pub struct MeshBuildingJob {
     pub is_selected: bool,
 }
 
+use crate::mesh_conversion;
+
 pub struct MeshBuildingJobOutcome {
-    pub geometry_mesh: geo_bevy::GeometryMesh,
+    pub geometry_mesh: mesh_conversion::GeometryMesh,
     pub layer_id: rgis_primitives::LayerId,
     pub is_selected: bool,
 }
 
 impl bevy_jobs::Job for MeshBuildingJob {
-    type Outcome = Result<MeshBuildingJobOutcome, geo_bevy::Error>;
+    type Outcome = Result<MeshBuildingJobOutcome, mesh_conversion::Error>;
 
     fn name(&self) -> String {
         "Building Bevy meshes".to_string()
     }
 
     async fn perform(self, _: bevy_jobs::Context) -> Self::Outcome {
-        let geometry_mesh = geo_bevy::geometry_to_mesh(&self.geometry)?;
+        let geometry_mesh = mesh_conversion::geometry_to_mesh(&self.geometry)?;
         Ok(MeshBuildingJobOutcome {
             geometry_mesh,
             layer_id: self.layer_id,

--- a/rgis-renderer/src/line_helper.rs
+++ b/rgis-renderer/src/line_helper.rs
@@ -1,0 +1,27 @@
+use bevy::{ecs::relationship::RelatedSpawnerCommands, prelude::*};
+
+use crate::{line_material::LineMaterial, RenderEntityType, Stroke, ZIndex};
+
+pub fn spawn_line_string_helper(
+    materials: &mut Assets<LineMaterial>,
+    color: Color,
+    width: f32,
+    layer_index: crate::rgis_layers::LayerIndex,
+    mesh: Mesh,
+    commands: &mut RelatedSpawnerCommands,
+    assets_meshes: &mut Assets<Mesh>,
+    entity_type: RenderEntityType,
+) {
+    let material = materials.add(LineMaterial { color, width });
+    let z_index = ZIndex::calculate(layer_index, entity_type);
+    commands.spawn((
+        MeshBundle {
+            mesh: assets_meshes.add(mesh),
+            transform: Transform::from_xyz(0., 0., z_index.0 as f32),
+            material,
+            ..Default::default()
+        },
+        entity_type,
+        Stroke,
+    ));
+}

--- a/rgis-renderer/src/line_material.rs
+++ b/rgis-renderer/src/line_material.rs
@@ -1,0 +1,45 @@
+use bevy::{
+    pbr::{MaterialPipeline, MaterialPipelineKey},
+    prelude::*,
+    reflect::TypePath,
+    render::{
+        mesh::{MeshVertexAttribute, MeshVertexBufferLayout},
+        render_resource::{
+            AsBindGroup, RenderPipelineDescriptor, ShaderRef, SpecializedMeshPipelineError,
+            VertexFormat,
+        },
+    },
+};
+
+#[derive(Asset, TypePath, AsBindGroup, Debug, Clone)]
+pub struct LineMaterial {
+    #[uniform(0)]
+    pub color: Color,
+    #[uniform(1)]
+    pub width: f32,
+}
+
+impl Material for LineMaterial {
+    fn vertex_shader() -> ShaderRef {
+        "shaders/line.wgsl".into()
+    }
+
+    fn fragment_shader() -> ShaderRef {
+        "shaders/line.wgsl".into()
+    }
+
+    fn specialize(
+        _pipeline: &MaterialPipeline<Self>,
+        descriptor: &mut RenderPipelineDescriptor,
+        layout: &MeshVertexBufferLayout,
+        _key: MaterialPipelineKey<Self>,
+    ) -> Result<(), SpecializedMeshPipelineError> {
+        let mut vertex_layout = layout.get_layout(&[
+            Mesh::ATTRIBUTE_POSITION.at_shader_location(0),
+            MeshVertexAttribute::new("PointA", 1, VertexFormat::Float32x3).at_shader_location(1),
+            MeshVertexAttribute::new("PointB", 2, VertexFormat::Float32x3).at_shader_location(2),
+        ])?;
+        descriptor.vertex.buffers = vec![vertex_layout];
+        Ok(())
+    }
+}

--- a/rgis-renderer/src/mesh_conversion/build_mesh.rs
+++ b/rgis-renderer/src/mesh_conversion/build_mesh.rs
@@ -1,0 +1,160 @@
+use geo_traits::{CoordTrait, GeometryType};
+use std::iter;
+
+pub trait BuildMesh {
+    fn build(self) -> Result<crate::mesh_conversion::GeometryMesh, crate::mesh_conversion::Error>;
+}
+
+pub struct BuildBevyMeshesContext<Scalar: geo_types::CoordFloat> {
+    pub point_mesh_builder: crate::mesh_conversion::point::PointMeshBuilder,
+    pub line_string_mesh_builder: crate::mesh_conversion::line_string::LineStringMeshBuilder,
+    pub polygon_mesh_builder: crate::mesh_conversion::polygon::PolygonMeshBuilder<Scalar>,
+}
+
+impl<Scalar: geo_types::CoordFloat> Default for BuildBevyMeshesContext<Scalar> {
+    fn default() -> Self {
+        Self {
+            point_mesh_builder: Default::default(),
+            line_string_mesh_builder: Default::default(),
+            polygon_mesh_builder: Default::default(),
+        }
+    }
+}
+
+fn populate_point_mesh_builders<Scalar: geo_types::CoordFloat>(
+    point: &impl geo_traits::PointTrait<T = Scalar>,
+    ctx: &mut BuildBevyMeshesContext<Scalar>,
+) -> Result<(), crate::mesh_conversion::Error> {
+    if let Some(coord) = point.coord() {
+        ctx.point_mesh_builder.add_coord(coord);
+    }
+    Ok(())
+}
+
+fn populate_line_string_mesh_builders<Scalar: geo_types::CoordFloat>(
+    line_string: &impl geo_traits::LineStringTrait<T = Scalar>,
+    ctx: &mut BuildBevyMeshesContext<Scalar>,
+) -> Result<(), crate::mesh_conversion::Error> {
+    ctx.line_string_mesh_builder
+        .add_coords(line_string.coords())
+}
+
+fn populate_polygon_mesh_builders<Scalar: geo_types::CoordFloat>(
+    polygon: &impl geo_traits::PolygonTrait<T = Scalar>,
+    ctx: &mut BuildBevyMeshesContext<Scalar>,
+) -> Result<(), crate::mesh_conversion::Error> {
+    ctx.polygon_mesh_builder.add_polygon(polygon)
+}
+
+fn populate_multi_point_mesh_builders<Scalar: geo_types::CoordFloat>(
+    multi_point: &impl geo_traits::MultiPointTrait<T = Scalar>,
+    ctx: &mut BuildBevyMeshesContext<Scalar>,
+) -> Result<(), crate::mesh_conversion::Error> {
+    for point in multi_point.points() {
+        populate_point_mesh_builders(&point, ctx)?;
+    }
+    Ok(())
+}
+
+fn populate_multi_line_string_mesh_builders<Scalar: geo_types::CoordFloat>(
+    multi_line_string: &impl geo_traits::MultiLineStringTrait<T = Scalar>,
+    ctx: &mut BuildBevyMeshesContext<Scalar>,
+) -> Result<(), crate::mesh_conversion::Error> {
+    for line_string in multi_line_string.line_strings() {
+        populate_line_string_mesh_builders(&line_string, ctx)?;
+    }
+    Ok(())
+}
+
+fn populate_multi_polygon_mesh_builders<Scalar: geo_types::CoordFloat>(
+    multi_polygon: &impl geo_traits::MultiPolygonTrait<T = Scalar>,
+    ctx: &mut BuildBevyMeshesContext<Scalar>,
+) -> Result<(), crate::mesh_conversion::Error> {
+    for polygon in multi_polygon.polygons() {
+        populate_polygon_mesh_builders(&polygon, ctx)?;
+    }
+    Ok(())
+}
+
+fn populate_geometry_collection_mesh_builders<Scalar: geo_types::CoordFloat>(
+    geometry_collection: &impl geo_traits::GeometryCollectionTrait<T = Scalar>,
+    ctx: &mut BuildBevyMeshesContext<Scalar>,
+) -> Result<(), crate::mesh_conversion::Error> {
+    for g in geometry_collection.geometries() {
+        populate_geometry_mesh_builders(&g, ctx)?;
+    }
+    Ok(())
+}
+
+fn populate_triangle_mesh_builders<Scalar: geo_types::CoordFloat>(
+    triangle: &impl geo_traits::TriangleTrait<T = Scalar>,
+    ctx: &mut BuildBevyMeshesContext<Scalar>,
+) -> Result<(), crate::mesh_conversion::Error> {
+    // TODO: build with earcutr directly
+    let polygon = geo_types::Polygon::new(
+        geo_types::LineString::new(
+            triangle
+                .coords()
+                .into_iter()
+                .map(|c| geo_types::Coord { x: c.x(), y: c.y() })
+                .collect(),
+        ),
+        vec![],
+    );
+    ctx.polygon_mesh_builder.add_polygon(&polygon)
+}
+
+fn populate_rect_mesh_builders<Scalar: geo_types::CoordFloat>(
+    rect: &impl geo_traits::RectTrait<T = Scalar>,
+    ctx: &mut BuildBevyMeshesContext<Scalar>,
+) -> Result<(), crate::mesh_conversion::Error> {
+    ctx.polygon_mesh_builder
+        .add_polygon_from_exterior_coords(rect_coords_iter(rect))
+}
+
+fn rect_coords_iter<
+    'a,
+    Scalar: geo_types::CoordFloat + 'a,
+    PointType: geo_traits::CoordTrait<T = Scalar> + 'a,
+>(
+    rect: &'a impl geo_traits::RectTrait<T = Scalar, CoordType<'a> = PointType>,
+) -> impl Iterator<Item = (Scalar, Scalar)> + Clone {
+    let (min, max) = (rect.min(), rect.max());
+    [
+        (min.x(), min.y()),
+        (min.x(), max.y()),
+        (max.x(), max.y()),
+        (max.x(), min.y()),
+    ]
+    .into_iter()
+}
+
+fn populate_line_mesh_builders<Scalar: geo_types::CoordFloat>(
+    line: &impl geo_traits::LineTrait<T = Scalar>,
+    ctx: &mut BuildBevyMeshesContext<Scalar>,
+) -> Result<(), crate::mesh_conversion::Error> {
+    let iter = iter::once(line.start()).chain(iter::once(line.end()));
+    ctx.line_string_mesh_builder.add_coords(iter)
+}
+
+pub fn populate_geometry_mesh_builders<
+    Scalar: geo_types::CoordFloat,
+    G: geo_traits::GeometryTrait<T = Scalar>,
+>(
+    geometry: &G,
+    ctx: &mut BuildBevyMeshesContext<Scalar>,
+) -> Result<(), crate::mesh_conversion::Error> {
+    match geometry.as_type() {
+        GeometryType::Point(g) => populate_point_mesh_builders(g, ctx)?,
+        GeometryType::LineString(g) => populate_line_string_mesh_builders(g, ctx)?,
+        GeometryType::Polygon(g) => populate_polygon_mesh_builders(g, ctx)?,
+        GeometryType::MultiPoint(g) => populate_multi_point_mesh_builders(g, ctx)?,
+        GeometryType::MultiLineString(g) => populate_multi_line_string_mesh_builders(g, ctx)?,
+        GeometryType::MultiPolygon(g) => populate_multi_polygon_mesh_builders(g, ctx)?,
+        GeometryType::GeometryCollection(g) => populate_geometry_collection_mesh_builders(g, ctx)?,
+        GeometryType::Triangle(g) => populate_triangle_mesh_builders(g, ctx)?,
+        GeometryType::Rect(g) => populate_rect_mesh_builders(g, ctx)?,
+        GeometryType::Line(g) => populate_line_mesh_builders(g, ctx)?,
+    }
+    Ok(())
+}

--- a/rgis-renderer/src/mesh_conversion/line_string.rs
+++ b/rgis-renderer/src/mesh_conversion/line_string.rs
@@ -1,0 +1,118 @@
+use bevy::{
+    prelude::Mesh,
+    render::mesh::{MeshVertexAttribute, VertexFormat},
+};
+use geo_traits::CoordTrait;
+use num_traits::cast::ToPrimitive;
+
+type Point = [f32; 3]; // [x, y, z]
+
+pub const ATTRIBUTE_POINT_A: MeshVertexAttribute =
+    MeshVertexAttribute::new("PointA", 1, VertexFormat::Float32x3);
+pub const ATTRIBUTE_POINT_B: MeshVertexAttribute =
+    MeshVertexAttribute::new("PointB", 2, VertexFormat::Float32x3);
+
+#[derive(Default)]
+pub struct LineStringMeshBuilder {
+    positions: Vec<Point>,
+    point_as: Vec<Point>,
+    point_bs: Vec<Point>,
+    indices: Vec<u32>,
+}
+
+impl LineStringMeshBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_coords<I, C>(&mut self, coords: I) -> Result<(), crate::Error>
+    where
+        I: Iterator<Item = C>,
+        C: CoordTrait,
+    {
+        let mut index_base = self.positions.len() as u32;
+
+        let mut last_coord = None;
+        for coord in coords {
+            if let Some(last_coord) = last_coord {
+                let a = [
+                    last_coord
+                        .x()
+                        .to_f32()
+                        .ok_or(crate::Error::CouldNotConvertToF32)?,
+                    last_coord
+                        .y()
+                        .to_f32()
+                        .ok_or(crate::Error::CouldNotConvertToF32)?,
+                    0.0,
+                ];
+                let b = [
+                    coord
+                        .x()
+                        .to_f32()
+                        .ok_or(crate::Error::CouldNotConvertToF32)?,
+                    coord
+                        .y()
+                        .to_f32()
+                        .ok_or(crate::Error::CouldNotConvertToF32)?,
+                    0.0,
+                ];
+
+                self.positions.push([0.0, -0.5, 0.0]);
+                self.positions.push([1.0, -0.5, 0.0]);
+                self.positions.push([1.0, 0.5, 0.0]);
+                self.positions.push([0.0, 0.5, 0.0]);
+
+                for _ in 0..4 {
+                    self.point_as.push(a);
+                    self.point_bs.push(b);
+                }
+
+                self.indices.push(index_base);
+                self.indices.push(index_base + 1);
+                self.indices.push(index_base + 2);
+                self.indices.push(index_base);
+                self.indices.push(index_base + 2);
+                self.indices.push(index_base + 3);
+
+                index_base += 4;
+            }
+            last_coord = Some(coord);
+        }
+
+        Ok(())
+    }
+}
+
+impl TryFrom<LineStringMeshBuilder> for Mesh {
+    type Error = crate::Error;
+
+    fn try_from(
+        line_string_mesh_builder: LineStringMeshBuilder,
+    ) -> Result<Self, Self::Error> {
+        if line_string_mesh_builder.positions.is_empty() {
+            Err(crate::Error::EmptyGeometry)
+        } else {
+            let mut mesh = Mesh::new(
+                bevy::render::render_resource::PrimitiveTopology::TriangleList,
+                Default::default(),
+            );
+            mesh.insert_indices(bevy::render::mesh::Indices::U32(
+                line_string_mesh_builder.indices,
+            ));
+            mesh.insert_attribute(
+                Mesh::ATTRIBUTE_POSITION,
+                line_string_mesh_builder.positions,
+            );
+            mesh.insert_attribute(ATTRIBUTE_POINT_A, line_string_mesh_builder.point_as);
+            mesh.insert_attribute(ATTRIBUTE_POINT_B, line_string_mesh_builder.point_bs);
+            Ok(mesh)
+        }
+    }
+}
+
+impl crate::build_mesh::BuildMesh for LineStringMeshBuilder {
+    fn build(self) -> Result<crate::GeometryMesh, crate::Error> {
+        Ok(crate::GeometryMesh::LineString(self.try_into()?))
+    }
+}

--- a/rgis-renderer/src/mesh_conversion/mod.rs
+++ b/rgis-renderer/src/mesh_conversion/mod.rs
@@ -1,0 +1,48 @@
+use bevy::prelude::{info_span, Mesh};
+use build_mesh::BuildMesh;
+use geo_traits::*;
+use line_string::LineStringMeshBuilder;
+use polygon::PolygonMeshBuilder;
+use std::iter;
+
+pub use point::SpritePosition;
+pub use polygon::PolygonMesh;
+
+mod build_mesh;
+mod line_string;
+mod point;
+mod polygon;
+
+pub fn geometry_to_mesh<Scalar: geo_types::CoordFloat>(
+    geometry: impl GeometryTrait<T = Scalar>,
+) -> Result<GeometryMesh, Error> {
+    let mut ctx = build_mesh::BuildBevyMeshesContext::default();
+
+    info_span!("Populating Bevy mesh builder")
+        .in_scope(|| build_mesh::populate_geometry_mesh_builders(&geometry, &mut ctx))?;
+
+    info_span!("Building Bevy meshes").in_scope(|| {
+        [
+            ctx.point_mesh_builder.build(),
+            ctx.line_string_mesh_builder.build(),
+            ctx.polygon_mesh_builder.build(),
+        ]
+        .into_iter()
+        .find(|prepared_mesh| prepared_mesh.is_ok())
+        .unwrap_or(Err(Error::CouldNotBuildMesh))
+    })
+}
+
+pub enum GeometryMesh {
+    Point(Vec<SpritePosition>),
+    LineString(Mesh),
+    Polygon(polygon::PolygonMesh),
+}
+
+#[derive(Debug)]
+pub enum Error {
+    CouldNotBuildMesh,
+    CouldNotConvertToF32,
+    EmptyGeometry,
+    BevyEarcutr(bevy_earcutr::Error),
+}

--- a/rgis-renderer/src/mesh_conversion/point.rs
+++ b/rgis-renderer/src/mesh_conversion/point.rs
@@ -1,0 +1,32 @@
+use geo_traits::CoordTrait;
+use num_traits::ToPrimitive;
+
+pub struct SpritePosition {
+    pub x: f32,
+    pub y: f32,
+}
+
+#[derive(Default)]
+pub struct PointMeshBuilder {
+    points: Vec<SpritePosition>,
+}
+
+impl PointMeshBuilder {
+    /// Call for `add_earcutr_input` for each polygon you want to add to the mesh.
+    pub fn add_coord(&mut self, coord: impl CoordTrait) {
+        self.points.push(SpritePosition {
+            x: coord.x().to_f32().unwrap(),
+            y: coord.y().to_f32().unwrap(),
+        });
+    }
+}
+
+impl crate::mesh_conversion::build_mesh::BuildMesh for PointMeshBuilder {
+    fn build(self) -> Result<crate::mesh_conversion::GeometryMesh, crate::mesh_conversion::Error> {
+        if self.points.is_empty() {
+            Err(crate::mesh_conversion::Error::EmptyGeometry)
+        } else {
+            Ok(crate::mesh_conversion::GeometryMesh::Point(self.points))
+        }
+    }
+}

--- a/rgis-renderer/src/mesh_conversion/polygon.rs
+++ b/rgis-renderer/src/mesh_conversion/polygon.rs
@@ -1,0 +1,157 @@
+use crate::mesh_conversion::line_string::LineStringMeshBuilder;
+use bevy::prelude::Mesh;
+use geo_traits::*;
+
+pub struct PolygonMesh {
+    pub mesh: Mesh,
+    pub exterior_mesh: Mesh,
+    pub interior_meshes: Vec<Mesh>,
+}
+
+pub struct PolygonMeshBuilder<Scalar: geo_types::CoordFloat> {
+    polygon: bevy_earcutr::PolygonMeshBuilder<Scalar>,
+    exterior: LineStringMeshBuilder,
+    interiors: Vec<LineStringMeshBuilder>,
+}
+
+impl<Scalar: geo_types::CoordFloat> Default for PolygonMeshBuilder<Scalar> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Scalar: geo_types::CoordFloat> PolygonMeshBuilder<Scalar> {
+    pub fn new() -> Self {
+        Self {
+            polygon: bevy_earcutr::PolygonMeshBuilder::default(),
+            exterior: LineStringMeshBuilder::default(),
+            interiors: Vec::new(),
+        }
+    }
+
+    pub fn add_polygon(
+        &mut self,
+        polygon: &impl geo_traits::PolygonTrait<T = Scalar>,
+    ) -> Result<(), crate::mesh_conversion::Error> {
+        self.polygon
+            .add_earcutr_input(Self::polygon_to_earcutr_input(polygon));
+        if let Some(exterior) = polygon.exterior() {
+            self.exterior.add_coords(exterior.coords())?;
+        }
+        for interior in polygon.interiors() {
+            self.interiors.push(LineStringMeshBuilder::default());
+            self.interiors
+                .last_mut()
+                .unwrap()
+                .add_coords(interior.coords())?;
+        }
+        Ok(())
+    }
+
+    pub fn add_polygon_from_exterior_coords(
+        &mut self,
+        coords: impl Iterator<Item = impl CoordTrait<T = Scalar>> + Clone,
+    ) -> Result<(), crate::mesh_conversion::Error> {
+        self.polygon
+            .add_earcutr_input(Self::exterior_coords_to_earcutr_input(coords.clone()));
+        self.exterior.add_coords(coords)?;
+        Ok(())
+    }
+
+    fn polygon_to_earcutr_input(
+        polygon: &impl geo_traits::PolygonTrait<T = Scalar>,
+    ) -> bevy_earcutr::EarcutrInput<Scalar> {
+        let mut vertices = Vec::with_capacity(polygon_coords_count(polygon) * 2);
+        let mut interior_indices = Vec::with_capacity(polygon.num_interiors());
+        debug_assert!(
+            polygon
+                .exterior()
+                .map_or(0, |exterior| exterior.num_coords())
+                >= 4
+        );
+
+        if let Some(exterior) = polygon.exterior() {
+            Self::flat_line_string_coords_2(exterior.coords(), &mut vertices);
+        }
+
+        for interior in polygon.interiors() {
+            debug_assert!(interior.num_coords() >= 4);
+            interior_indices.push(vertices.len() / 2);
+            Self::flat_line_string_coords_2(interior.coords(), &mut vertices);
+        }
+
+        bevy_earcutr::EarcutrInput {
+            vertices,
+            interior_indices,
+        }
+    }
+
+    fn exterior_coords_to_earcutr_input(
+        exterior: impl Iterator<Item = impl CoordTrait<T = Scalar>> + Clone,
+    ) -> bevy_earcutr::EarcutrInput<Scalar> {
+        let count = exterior.clone().count();
+        let mut vertices = Vec::with_capacity(count * 2);
+        debug_assert!(count >= 4);
+
+        Self::flat_line_string_coords_2(exterior, &mut vertices);
+
+        bevy_earcutr::EarcutrInput {
+            vertices,
+            interior_indices: vec![],
+        }
+    }
+
+    fn flat_line_string_coords_2(
+        line_string_coords: impl Iterator<Item = impl CoordTrait<T = Scalar>>,
+        vertices: &mut Vec<Scalar>,
+    ) {
+        for coord in line_string_coords {
+            vertices.push(coord.x());
+            vertices.push(coord.y());
+        }
+    }
+}
+
+fn polygon_coords_count<P: PolygonTrait>(polygon: &P) -> usize {
+    polygon
+        .exterior()
+        .map_or(0, |exterior| exterior.num_coords())
+        + polygon
+            .interiors()
+            .map(|interior| interior.num_coords())
+            .sum::<usize>()
+}
+
+impl<Scalar: geo_types::CoordFloat> TryFrom<PolygonMeshBuilder<Scalar>> for PolygonMesh {
+    type Error = crate::mesh_conversion::Error;
+
+    fn try_from(polygon_mesh_builder: PolygonMeshBuilder<Scalar>) -> Result<Self, Self::Error> {
+        polygon_mesh_builder
+            .polygon
+            .build()
+            .map_err(crate::mesh_conversion::Error::BevyEarcutr)
+            .and_then(|polygon_mesh| {
+                let exterior_mesh = Mesh::try_from(polygon_mesh_builder.exterior)?;
+                let interior_meshes = polygon_mesh_builder
+                    .interiors
+                    .into_iter()
+                    .map(Mesh::try_from)
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(PolygonMesh {
+                    mesh: polygon_mesh,
+                    exterior_mesh,
+                    interior_meshes,
+                })
+            })
+    }
+}
+
+impl<Scalar: geo_types::CoordFloat> crate::mesh_conversion::build_mesh::BuildMesh
+    for PolygonMeshBuilder<Scalar>
+{
+    fn build(self) -> Result<crate::mesh_conversion::GeometryMesh, crate::mesh_conversion::Error> {
+        Ok(crate::mesh_conversion::GeometryMesh::Polygon(
+            PolygonMesh::try_from(self)?,
+        ))
+    }
+}

--- a/rgis-ui/src/systems.rs
+++ b/rgis-ui/src/systems.rs
@@ -53,12 +53,15 @@ fn handle_open_file_job(
     }
 }
 
+use rgis_layer_events::LayerStrokeWidthUpdatedEvent;
+
 fn render_manage_layer_window(
     mut state: Local<crate::ManageLayerWindowState>,
     mut bevy_egui_ctx: EguiContexts,
     layers: Res<rgis_layers::Layers>,
     mut color_events: ResMut<Events<rgis_ui_events::UpdateLayerColorEvent>>,
     mut point_size_events: ResMut<Events<rgis_ui_events::UpdateLayerPointSizeEvent>>,
+    mut stroke_width_events: ResMut<Events<LayerStrokeWidthUpdatedEvent>>,
     mut show_manage_layer_window_event_reader: EventReader<
         rgis_ui_events::ShowManageLayerWindowEvent,
     >,
@@ -76,6 +79,7 @@ fn render_manage_layer_window(
         egui_ctx: bevy_egui_ctx_mut,
         color_events: &mut color_events,
         point_size_events: &mut point_size_events,
+        stroke_width_events: &mut stroke_width_events,
         duplicate_layer_events: &mut duplicate_layer_events,
     }
     .render();

--- a/rgis-ui/src/widgets/mod.rs
+++ b/rgis-ui/src/widgets/mod.rs
@@ -9,6 +9,7 @@ pub mod toggle_layer;
 pub mod fill_color;
 pub mod point_size;
 pub mod stroke_color;
+pub mod stroke_width;
 
 pub mod exit;
 pub mod full_screen;

--- a/rgis-ui/src/widgets/stroke_width.rs
+++ b/rgis-ui/src/widgets/stroke_width.rs
@@ -1,0 +1,22 @@
+use bevy::prelude::*;
+use bevy_egui::{egui, EguiContexts};
+use rgis_layer_events::LayerStrokeWidthUpdatedEvent;
+use rgis_layers::Layers;
+
+pub fn stroke_width(
+    egui_ctx: &mut egui::Context,
+    layers: &Layers,
+    event_writer: &mut EventWriter<LayerStrokeWidthUpdatedEvent>,
+) {
+    if let Some(layer) = layers.selected_layer() {
+        let mut stroke_width = layer.stroke_width;
+        if egui::DragValue::new(&mut stroke_width)
+            .speed(0.1)
+            .clamp_range(0.1..=100.0)
+            .ui(egui_ctx)
+            .changed()
+        {
+            event_writer.send(LayerStrokeWidthUpdatedEvent(layer.id, stroke_width));
+        }
+    }
+}

--- a/rgis-ui/src/windows/manage_layer.rs
+++ b/rgis-ui/src/windows/manage_layer.rs
@@ -3,12 +3,15 @@ use bevy_egui::egui;
 use rgis_layer_events::DuplicateLayerEvent;
 use rgis_ui_events::{UpdateLayerColorEvent, UpdateLayerPointSizeEvent};
 
+use rgis_layer_events::LayerStrokeWidthUpdatedEvent;
+
 pub struct ManageLayer<'a> {
     pub state: &'a mut crate::ManageLayerWindowState,
     pub layers: &'a rgis_layers::Layers,
     pub egui_ctx: &'a mut bevy_egui::egui::Context,
     pub color_events: &'a mut Events<UpdateLayerColorEvent>,
     pub point_size_events: &'a mut Events<UpdateLayerPointSizeEvent>,
+    pub stroke_width_events: &'a mut Events<LayerStrokeWidthUpdatedEvent>,
     pub duplicate_layer_events: &'a mut Events<DuplicateLayerEvent>,
 }
 
@@ -71,6 +74,15 @@ impl ManageLayer<'_> {
                             });
                             ui.end_row();
                         }
+                    if layer.geom_type.has_stroke() {
+                        ui.label("Stroke width");
+                        crate::widgets::stroke_width::stroke_width(
+                            self.egui_ctx,
+                            self.layers,
+                            self.stroke_width_events,
+                        );
+                        ui.end_row();
+                    }
                     });
                 ui.separator();
                 if ui.button("Duplicate").clicked() {

--- a/rgis/assets/shaders/line.wgsl
+++ b/rgis/assets/shaders/line.wgsl
@@ -1,0 +1,26 @@
+#import bevy_pbr::mesh_view_bindings
+#import bevy_pbr::mesh_functions
+
+@group(1) @binding(0) var<uniform> color: vec4<f32>;
+@group(1) @binding(1) var<uniform> width: f32;
+
+@vertex
+fn vertex(
+    @location(0) vert_pos: vec3<f32>,
+    @location(1) point_a: vec3<f32>,
+    @location(2) point_b: vec3<f32>,
+) -> @builtin(position) vec4<f32> {
+    let x_basis = point_b.xy - point_a.xy;
+    let y_basis = normalize(vec2<f32>(-x_basis.y, x_basis.x));
+
+    let point = point_a.xy + x_basis * vert_pos.x + y_basis * width * vert_pos.y;
+
+    let world_position = vec4<f32>(point.xy, 0.0, 1.0);
+
+    return mesh_view_bindings::view.view_proj * mesh_view_bindings::globals.model * world_position;
+}
+
+@fragment
+fn fragment() -> @location(0) vec4<f32> {
+    return color;
+}


### PR DESCRIPTION
This commit introduces the functionality to render lines with a specified thickness, instead of a single pixel width.

The main changes are:
- A new WGSL shader (`rgis/assets/shaders/line.wgsl`) is added to handle the rendering of thick lines. The vertex shader expands each line segment into a quad.
- A custom `LineMaterial` is defined in `rgis-renderer/src/line_material.rs`, with `color` and `width` uniforms.
- The mesh generation for line strings has been updated to produce a `TriangleList` of quads. This is done in a new `rgis-renderer/src/mesh_conversion` module, which is a custom implementation based on the `geo-bevy` crate.
- The rendering systems in `rgis-renderer/src/systems.rs` have been updated to support the new `LineMaterial`.
- A new UI widget for controlling the stroke width has been added in `rgis-ui/src/widgets/stroke_width.rs` and integrated into the "Manage Layer" window.
- The `Layer` struct in `rgis-layers/src/lib.rs` has been updated to include a `stroke_width` field.
- A new `LayerStrokeWidthUpdatedEvent` has been added to `rgis-layer-events/src/lib.rs`.