### PR TITLE
Export egui widget positions for robust Playwright tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5084,6 +5084,7 @@ dependencies = [
  "bevy_jobs",
  "geo",
  "getrandom 0.2.17",
+ "js-sys",
  "rgis-camera",
  "rgis-camera-events",
  "rgis-cli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ geozero = { git = "https://github.com/georust/geozero.git", branch = "main" }
 num-t = "5"
 rfd = "0.15"
 getrandom = { version = "0.2", features = ["js"] }
+js-sys = "0.3"
 wasm-bindgen = "0.2"
 
 [profile.release]

--- a/rgis-ui/src/lib.rs
+++ b/rgis-ui/src/lib.rs
@@ -2,6 +2,7 @@ use bevy::prelude::*;
 
 mod panels;
 mod systems;
+pub mod widget_registry;
 mod widgets;
 mod windows;
 

--- a/rgis-ui/src/panels/bottom.rs
+++ b/rgis-ui/src/panels/bottom.rs
@@ -27,7 +27,9 @@ impl Bottom<'_, '_> {
     fn render_crs(&mut self, ui: &mut egui::Ui) {
         // TODO: The ordering is backwards here (the edit button should be specified after)
         //       Is this from the right_to_left call above?
-        if ui.button("✏").clicked() {
+        let edit_btn = ui.button("✏");
+        crate::widget_registry::register("Edit CRS", edit_btn.rect);
+        if edit_btn.clicked() {
             self.open_change_crs_window_event_writer.write_default();
         }
 

--- a/rgis-ui/src/panels/side.rs
+++ b/rgis-ui/src/panels/side.rs
@@ -125,7 +125,7 @@ impl Widget for Layer<'_, '_> {
             is_move_down_enabled,
             events: _,
         } = self;
-        egui::CollapsingHeader::new(&layer.name)
+        let header = egui::CollapsingHeader::new(&layer.name)
             .id_salt(layer.id) // Instead of using the layer name as the ID (which is not unique), use the layer ID
             .show(ui, |ui| {
                 if !layer.is_active() {
@@ -136,7 +136,9 @@ impl Widget for Layer<'_, '_> {
                 ui.label(format!("Type: {}", layer.geom_type));
 
                 ui.with_layout(Layout::top_down_justified(Align::Center), |ui| {
-                    if ui.button("✏ Manage").clicked() {
+                    let manage_btn = ui.button("✏ Manage");
+                    crate::widget_registry::register("Manage", manage_btn.rect);
+                    if manage_btn.clicked() {
                         self.events
                             .show_manage_layer_window_event_writer
                             .write(ShowManageLayerWindowEvent(layer.id));
@@ -154,17 +156,21 @@ impl Widget for Layer<'_, '_> {
                         events: self.events,
                     });
 
-                    if ui.button("🔎 Zoom to extent").clicked() {
+                    let zoom_btn = ui.button("🔎 Zoom to extent");
+                    crate::widget_registry::register("Zoom to extent", zoom_btn.rect);
+                    if zoom_btn.clicked() {
                         self.events
                             .center_layer_event_writer
                             .write(CenterCameraEvent(layer.id));
                     }
 
-                    if ui.button("❌ Remove").clicked() {
+                    let remove_btn = ui.button("❌ Remove");
+                    crate::widget_registry::register("Remove", remove_btn.rect);
+                    if remove_btn.clicked() {
                         self.delete_layer(layer);
                     }
 
-                    egui::CollapsingHeader::new("⚙ Operations")
+                    let ops_header = egui::CollapsingHeader::new("⚙ Operations")
                         .id_salt(format!("{:?}-operations", layer.id)) // Instead of using the layer name as the ID (which is not unique), use the layer ID
                         .show(ui, |ui| {
                             ui.with_layout(Layout::top_down_justified(Align::LEFT), |ui| {
@@ -174,8 +180,10 @@ impl Widget for Layer<'_, '_> {
                                 });
                             });
                         });
+                    crate::widget_registry::register("Operations", ops_header.header_response.rect);
                 });
-            })
-            .header_response
+            });
+        crate::widget_registry::register(&layer.name, header.header_response.rect);
+        header.header_response
     }
 }

--- a/rgis-ui/src/panels/top.rs
+++ b/rgis-ui/src/panels/top.rs
@@ -18,12 +18,13 @@ impl Top<'_, '_, '_> {
                 let prev_current_tool = self.app_settings.current_tool;
 
                 ui.label("rgis");
-                ui.menu_button("File", |ui| {
+                let file_response = ui.menu_button("File", |ui| {
                     ui.add(crate::widgets::exit::Exit {
                         app_exit_events: self.app_exit_events,
                     });
                 });
-                ui.menu_button("View", |ui| {
+                crate::widget_registry::register("File", file_response.response.rect);
+                let view_response = ui.menu_button("View", |ui| {
                     ui.add(crate::widgets::full_screen::FullScreen {
                         window: self.window,
                     });
@@ -41,49 +42,58 @@ impl Top<'_, '_, '_> {
                         self.app_settings.show_scale = !self.app_settings.show_scale;
                     }
                 });
-                ui.menu_button("Help", |ui| {
-                    if ui.button("Debug stats").clicked() {
+                crate::widget_registry::register("View", view_response.response.rect);
+                let help_response = ui.menu_button("Help", |ui| {
+                    let debug_btn = ui.button("Debug stats");
+                    crate::widget_registry::register("Debug stats", debug_btn.rect);
+                    if debug_btn.clicked() {
                         self.is_debug_window_open.0 = true;
                     }
-                    if ui.button("Source code").clicked() {
+                    let source_btn = ui.button("Source code");
+                    crate::widget_registry::register("Source code", source_btn.rect);
+                    if source_btn.clicked() {
                         ui.ctx().open_url(egui::OpenUrl {
                             url: String::from("https://github.com/frewsxcv/rgis"),
                             new_tab: true,
                         });
                     }
                 });
+                crate::widget_registry::register("Help", help_response.response.rect);
 
                 ui.separator();
 
-                if ui
+                let pan_btn = ui
                     .add_enabled(
                         self.app_settings.current_tool != rgis_settings::Tool::Pan,
                         egui::Button::new("🔁 Pan Tool")
                             .selected(self.app_settings.current_tool == rgis_settings::Tool::Pan),
-                    )
-                    .clicked()
+                    );
+                crate::widget_registry::register("Pan Tool", pan_btn.rect);
+                if pan_btn.clicked()
                 {
                     self.app_settings.current_tool = rgis_settings::Tool::Pan;
                 }
 
-                if ui
+                let query_btn = ui
                     .add_enabled(
                         self.app_settings.current_tool != rgis_settings::Tool::Query,
                         egui::Button::new("ℹ Query Tool")
                             .selected(self.app_settings.current_tool == rgis_settings::Tool::Query),
-                    )
-                    .clicked()
+                    );
+                crate::widget_registry::register("Query Tool", query_btn.rect);
+                if query_btn.clicked()
                 {
                     self.app_settings.current_tool = rgis_settings::Tool::Query;
                 }
 
-                if ui
+                let measure_btn = ui
                     .add_enabled(
                         self.app_settings.current_tool != rgis_settings::Tool::Measure,
                         egui::Button::new("📏 Measure Tool")
                             .selected(self.app_settings.current_tool == rgis_settings::Tool::Measure),
-                    )
-                    .clicked()
+                    );
+                crate::widget_registry::register("Measure Tool", measure_btn.rect);
+                if measure_btn.clicked()
                 {
                     self.app_settings.current_tool = rgis_settings::Tool::Measure;
                 }

--- a/rgis-ui/src/widget_registry.rs
+++ b/rgis-ui/src/widget_registry.rs
@@ -1,0 +1,33 @@
+#[cfg(target_arch = "wasm32")]
+mod inner {
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    thread_local! {
+        static POSITIONS: RefCell<HashMap<String, [f32; 4]>> = RefCell::new(HashMap::new());
+    }
+
+    pub fn register(label: &str, rect: bevy_egui::egui::Rect) {
+        POSITIONS.with(|p| {
+            p.borrow_mut().insert(
+                label.to_string(),
+                [rect.min.x, rect.min.y, rect.max.x, rect.max.y],
+            );
+        });
+    }
+
+    pub fn get(label: &str) -> Option<[f32; 4]> {
+        POSITIONS.with(|p| p.borrow().get(label).copied())
+    }
+
+    pub fn get_all() -> HashMap<String, [f32; 4]> {
+        POSITIONS.with(|p| p.borrow().clone())
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use inner::*;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[inline]
+pub fn register(_label: &str, _rect: bevy_egui::egui::Rect) {}

--- a/rgis-ui/src/widgets/add_layer.rs
+++ b/rgis-ui/src/widgets/add_layer.rs
@@ -8,6 +8,7 @@ pub struct AddLayer<'a, 'w> {
 impl egui::Widget for AddLayer<'_, '_> {
     fn ui(self, ui: &mut egui::Ui) -> egui::Response {
         let button = ui.button("➕ Add Layer");
+        crate::widget_registry::register("Add Layer", button.rect);
 
         if button.clicked() {
             self.events

--- a/rgis-ui/src/widgets/toggle_layer.rs
+++ b/rgis-ui/src/widgets/toggle_layer.rs
@@ -14,6 +14,7 @@ impl egui::Widget for ToggleLayer<'_, '_> {
         } else {
             ui.button("👁 Show")
         };
+        crate::widget_registry::register("Toggle Visibility", button.rect);
 
         if button.clicked() {
             self.events

--- a/rgis-ui/src/windows/add_layer/by_file.rs
+++ b/rgis-ui/src/windows/add_layer/by_file.rs
@@ -15,29 +15,33 @@ impl<'a> ByFile<'a> {
 
         ui.label("Format:");
 
-        ui.radio_value(
+        let geojson_radio = ui.radio_value(
             &mut self.state.selected_format,
             Some(FileFormat::GeoJson),
             "GeoJSON",
         );
+        crate::widget_registry::register("GeoJSON", geojson_radio.rect);
 
-        ui.radio_value(
+        let gpx_radio = ui.radio_value(
             &mut self.state.selected_format,
             Some(FileFormat::Gpx),
             "GPX",
         );
+        crate::widget_registry::register("GPX", gpx_radio.rect);
 
-        ui.radio_value(
+        let shapefile_radio = ui.radio_value(
             &mut self.state.selected_format,
             Some(FileFormat::Shapefile),
             "Shapefile",
         );
+        crate::widget_registry::register("Shapefile", shapefile_radio.rect);
 
-        ui.radio_value(
+        let wkt_radio = ui.radio_value(
             &mut self.state.selected_format,
             Some(FileFormat::Wkt),
             "WKT",
         );
+        crate::widget_registry::register("WKT", wkt_radio.rect);
 
         let Some(selected_format) = self.state.selected_format else {
             return None;

--- a/rgis-ui/src/windows/add_layer/by_text.rs
+++ b/rgis-ui/src/windows/add_layer/by_text.rs
@@ -15,23 +15,26 @@ impl<'a> ByText<'a> {
 
         ui.label("Format:");
 
-        ui.radio_value(
+        let geojson_radio = ui.radio_value(
             &mut self.state.selected_format,
             Some(FileFormat::GeoJson),
             "GeoJSON",
         );
+        crate::widget_registry::register("GeoJSON", geojson_radio.rect);
 
-        ui.radio_value(
+        let gpx_radio = ui.radio_value(
             &mut self.state.selected_format,
             Some(FileFormat::Gpx),
             "GPX",
         );
+        crate::widget_registry::register("GPX", gpx_radio.rect);
 
-        ui.radio_value(
+        let wkt_radio = ui.radio_value(
             &mut self.state.selected_format,
             Some(FileFormat::Wkt),
             "WKT",
         );
+        crate::widget_registry::register("WKT", wkt_radio.rect);
 
         let Some(selected_format) = self.state.selected_format else {
             return None;

--- a/rgis-ui/src/windows/add_layer/library.rs
+++ b/rgis-ui/src/windows/add_layer/library.rs
@@ -13,7 +13,7 @@ impl LibraryWidget<'_> {
         ui.vertical(|ui| {
             ui.heading("Library");
             for folder in rgis_library::get() {
-                ui.collapsing(format!("📁 {}", folder.name), |ui| {
+                let folder_header = ui.collapsing(format!("📁 {}", folder.name), |ui| {
                     for entry in &folder.entries {
                         if let Some(new_output) = (LibraryEntryWidget {
                             folder,
@@ -26,6 +26,7 @@ impl LibraryWidget<'_> {
                         }
                     }
                 });
+                crate::widget_registry::register(folder.name, folder_header.header_response.rect);
             }
         });
         output
@@ -42,7 +43,9 @@ impl LibraryEntryWidget<'_> {
     fn show(self, ui: &mut egui::Ui) -> Option<AddLayerOutput> {
         let mut output = None;
         ui.horizontal(|ui| {
-            if ui.button("➕ Add").clicked() {
+            let add_btn = ui.button("➕ Add");
+            crate::widget_registry::register(&format!("Add:{}", self.entry.name), add_btn.rect);
+            if add_btn.clicked() {
                 let mut geodesy_ctx = self.geodesy_ctx.0.write().unwrap();
                 let op_handle =
                     rgis_geodesy::epsg_code_to_geodesy_op_handle(&mut *geodesy_ctx, self.entry.crs)

--- a/rgis-ui/src/windows/add_layer/mod.rs
+++ b/rgis-ui/src/windows/add_layer/mod.rs
@@ -94,9 +94,12 @@ impl AddLayer<'_> {
                 .show(self.egui_ctx, |ui| {
                     ui.label("Layer source:");
 
-                    ui.radio_value(&mut self.state.selected_source, Source::Library, "Library");
-                    ui.radio_value(&mut self.state.selected_source, Source::File, "File");
-                    ui.radio_value(&mut self.state.selected_source, Source::Text, "Text");
+                    let library_radio = ui.radio_value(&mut self.state.selected_source, Source::Library, "Library");
+                    crate::widget_registry::register("Library", library_radio.rect);
+                    let file_radio = ui.radio_value(&mut self.state.selected_source, Source::File, "File");
+                    crate::widget_registry::register("File", file_radio.rect);
+                    let text_radio = ui.radio_value(&mut self.state.selected_source, Source::Text, "Text");
+                    crate::widget_registry::register("Text", text_radio.rect);
 
                     if self.state.selected_source == Source::Unselected {
                         return;

--- a/rgis/Cargo.toml
+++ b/rgis/Cargo.toml
@@ -37,6 +37,7 @@ rgis-cli = { path = "../rgis-cli" }
 bevy = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = { workspace = true }
 wasm-bindgen = { workspace = true }
 bevy = { workspace = true, features = ["webgl2"] }
 getrandom = { workspace = true }

--- a/rgis/src/lib.rs
+++ b/rgis/src/lib.rs
@@ -2,6 +2,36 @@ use bevy::prelude::*;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+pub fn get_widget_rect(label: &str) -> JsValue {
+    match rgis_ui::widget_registry::get(label) {
+        Some(rect) => {
+            let arr = js_sys::Array::new();
+            for v in rect {
+                arr.push(&JsValue::from_f64(f64::from(v)));
+            }
+            arr.into()
+        }
+        None => JsValue::NULL,
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+pub fn get_all_widget_rects() -> JsValue {
+    let all = rgis_ui::widget_registry::get_all();
+    let obj = js_sys::Object::new();
+    for (label, rect) in &all {
+        let arr = js_sys::Array::new();
+        for v in rect {
+            arr.push(&JsValue::from_f64(f64::from(*v)));
+        }
+        let _ = js_sys::Reflect::set(&obj, &JsValue::from_str(label), &arr);
+    }
+    obj.into()
+}
+
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 pub fn run() {
     let mut app = App::new();

--- a/www/index.js
+++ b/www/index.js
@@ -1,8 +1,11 @@
-import init, { run } from "rgis-pkg/rgis.js";
+import init, { run, get_widget_rect, get_all_widget_rects } from "rgis-pkg/rgis.js";
 
 async function main() {
     // Initialize the wasm module
     await init();
+    // Expose widget position functions for Playwright tests
+    window.get_widget_rect = get_widget_rect;
+    window.get_all_widget_rects = get_all_widget_rects;
     // Signal that WASM has loaded and initialized
     document.title = "rgis - ready";
     // Call the run function

--- a/www/tests/add-layer-window.spec.ts
+++ b/www/tests/add-layer-window.spec.ts
@@ -9,15 +9,13 @@ test.describe("add layer window - source selection", () => {
   test("selecting Library source shows library folders", async ({
     appPage,
   }) => {
-    // Click "Library" radio button
-    await appPage.clickOnCanvas(0.148, 0.146);
+    await appPage.clickWidget("Library");
     await appPage.page.waitForTimeout(500);
     await expect(appPage.page).toHaveScreenshot("add-layer-library-view.png");
   });
 
   test("selecting File source shows format options", async ({ appPage }) => {
-    // Click "File" radio button at ~170px x, ~126px y
-    await appPage.clickOnCanvas(0.133, 0.175);
+    await appPage.clickWidget("File");
     await appPage.page.waitForTimeout(500);
     await expect(appPage.page).toHaveScreenshot("add-layer-file-view.png");
   });
@@ -25,8 +23,7 @@ test.describe("add layer window - source selection", () => {
   test("selecting Text source shows format and text input", async ({
     appPage,
   }) => {
-    // Click "Text" radio button at ~170px x, ~147px y
-    await appPage.clickOnCanvas(0.133, 0.204);
+    await appPage.clickWidget("Text");
     await appPage.page.waitForTimeout(500);
     await expect(appPage.page).toHaveScreenshot("add-layer-text-view.png");
   });
@@ -34,12 +31,10 @@ test.describe("add layer window - source selection", () => {
 
 test.describe("add layer window - library tab", () => {
   test("expanding Russia folder shows Country entry", async ({ appPage }) => {
-    // Click Library radio
-    await appPage.clickOnCanvas(0.148, 0.146);
+    await appPage.clickWidget("Library");
     await appPage.page.waitForTimeout(500);
 
-    // Click the Russia folder to expand it
-    await appPage.clickOnCanvas(0.137, 0.31);
+    await appPage.clickWidget("Russia");
     await appPage.page.waitForTimeout(500);
     await expect(appPage.page).toHaveScreenshot(
       "library-russia-folder-expanded.png",
@@ -47,12 +42,10 @@ test.describe("add layer window - library tab", () => {
   });
 
   test("expanding USA folder shows States entry", async ({ appPage }) => {
-    // Click Library radio
-    await appPage.clickOnCanvas(0.148, 0.146);
+    await appPage.clickWidget("Library");
     await appPage.page.waitForTimeout(500);
 
-    // Click the USA folder to expand it
-    await appPage.clickOnCanvas(0.137, 0.338);
+    await appPage.clickWidget("USA");
     await appPage.page.waitForTimeout(500);
     await expect(appPage.page).toHaveScreenshot(
       "library-usa-folder-expanded.png",
@@ -60,12 +53,10 @@ test.describe("add layer window - library tab", () => {
   });
 
   test("expanding World folder shows entries", async ({ appPage }) => {
-    // Click Library radio
-    await appPage.clickOnCanvas(0.148, 0.146);
+    await appPage.clickWidget("Library");
     await appPage.page.waitForTimeout(500);
 
-    // Click the World folder to expand it
-    await appPage.clickOnCanvas(0.137, 0.424);
+    await appPage.clickWidget("World");
     await appPage.page.waitForTimeout(500);
     await expect(appPage.page).toHaveScreenshot(
       "library-world-folder-expanded.png",
@@ -75,12 +66,10 @@ test.describe("add layer window - library tab", () => {
 
 test.describe("add layer window - file tab", () => {
   test("selecting GeoJSON format in file tab", async ({ appPage }) => {
-    // Click File radio at ~170px x, ~126px y
-    await appPage.clickOnCanvas(0.133, 0.175);
+    await appPage.clickWidget("File");
     await appPage.page.waitForTimeout(500);
 
-    // Select GeoJSON format radio - first format option
-    await appPage.clickOnCanvas(0.133, 0.27);
+    await appPage.clickWidget("GeoJSON");
     await appPage.page.waitForTimeout(500);
     await expect(appPage.page).toHaveScreenshot(
       "file-tab-geojson-selected.png",
@@ -88,16 +77,13 @@ test.describe("add layer window - file tab", () => {
   });
 
   test("selecting Shapefile format in file tab", async ({ appPage }) => {
-    // Click File radio at ~170px x, ~126px y
-    await appPage.clickOnCanvas(0.133, 0.175);
+    await appPage.clickWidget("File");
     await appPage.page.waitForTimeout(500);
 
-    // Select Shapefile format radio (third option)
-    await appPage.clickOnCanvas(0.133, 0.33);
+    await appPage.clickWidget("Shapefile");
     await appPage.page.waitForTimeout(500);
     await expect(appPage.page).toHaveScreenshot(
       "file-tab-shapefile-selected.png",
     );
   });
 });
-

--- a/www/tests/bottom-panel.spec.ts
+++ b/www/tests/bottom-panel.spec.ts
@@ -12,9 +12,8 @@ test.describe("bottom panel - status bar", () => {
     await appPage.clickOnCanvas(0.7, 0.5);
     await appPage.page.waitForTimeout(500);
 
-    // Click the ✏ (pencil) button next to CRS display in bottom-right
-    // It's at far right of the bottom bar, roughly x=1260, y=710 in 1280x720
-    await appPage.clickOnCanvas(0.984, 0.986);
+    // Click the CRS edit button
+    await appPage.clickWidget("Edit CRS");
     await appPage.page.waitForTimeout(500);
     await expect(appPage.page).toHaveScreenshot("change-crs-window-open.png");
   });

--- a/www/tests/change-crs-window.spec.ts
+++ b/www/tests/change-crs-window.spec.ts
@@ -6,9 +6,8 @@ test.describe("change CRS window", () => {
     await appPage.clickOnCanvas(0.7, 0.5);
     await appPage.page.waitForTimeout(500);
 
-    // Click the ✏ button in bottom panel to open Change CRS window
-    // Pencil button at far right bottom: ~1260px x, ~710px y in 1280x720
-    await appPage.clickOnCanvas(0.984, 0.986);
+    // Click the CRS edit button in bottom panel
+    await appPage.clickWidget("Edit CRS");
     await appPage.page.waitForTimeout(500);
     await expect(appPage.page).toHaveScreenshot("change-crs-window.png");
   });

--- a/www/tests/debug-window.spec.ts
+++ b/www/tests/debug-window.spec.ts
@@ -2,13 +2,12 @@ import { test, expect } from "./fixtures/app-fixture";
 
 test.describe("debug window", () => {
   test("opening debug window from Help menu", async ({ appPage }) => {
-    // Click "Help" menu at ~120px from left, ~11px from top
-    await appPage.clickOnCanvas(0.094, 0.015);
+    // Click "Help" menu
+    await appPage.clickWidget("Help");
     await appPage.page.waitForTimeout(500);
 
-    // Click "Debug stats" in dropdown - it's the first item below Help
-    // Menu items appear below the menu button, roughly at ~120px x, ~35px y
-    await appPage.clickOnCanvas(0.094, 0.049);
+    // Click "Debug stats" in dropdown
+    await appPage.clickWidget("Debug stats");
     await appPage.page.waitForTimeout(1000);
     await expect(appPage.page).toHaveScreenshot("debug-window-open.png");
   });

--- a/www/tests/fixtures/app-fixture.ts
+++ b/www/tests/fixtures/app-fixture.ts
@@ -39,6 +39,27 @@ export class AppPage {
     await this.page.waitForTimeout(500);
   }
 
+  async clickWidget(label: string) {
+    const rect = await this.page.evaluate(
+      (l) => (window as any).get_widget_rect(l),
+      label,
+    );
+    if (!rect)
+      throw new Error(
+        `Widget "${label}" not found. Available: ${await this.listWidgets()}`,
+      );
+    const cx = (rect[0] + rect[2]) / 2;
+    const cy = (rect[1] + rect[3]) / 2;
+    await this.page.mouse.click(cx, cy);
+    await this.page.waitForTimeout(500);
+  }
+
+  async listWidgets(): Promise<string> {
+    return await this.page.evaluate(() =>
+      JSON.stringify((window as any).get_all_widget_rects()),
+    );
+  }
+
   async regionHasContent(
     xFrac: number,
     yFrac: number,

--- a/www/tests/layer-management.spec.ts
+++ b/www/tests/layer-management.spec.ts
@@ -5,21 +5,20 @@ test.describe("layer management", () => {
     test.setTimeout(60000);
 
     // Load World Countries from library
-    // Click Library radio at ~190px x, ~106px y
-    await appPage.clickOnCanvas(0.148, 0.147);
+    await appPage.clickWidget("Library");
     await appPage.page.waitForTimeout(500);
 
     // Expand World folder
-    await appPage.clickOnCanvas(0.137, 0.424);
+    await appPage.clickWidget("World");
     await appPage.page.waitForTimeout(500);
 
     // Click "+ Add" button next to Countries
-    await appPage.clickOnCanvas(0.162, 0.454);
+    await appPage.clickWidget("Add:Countries");
 
     // Wait for layer to load
     await appPage.page.waitForTimeout(10000);
 
-    // Close the Add Layer window by clicking its X button (~284px x, ~55px y)
+    // Close the Add Layer window by clicking its X button
     await appPage.clickOnCanvas(0.222, 0.076);
     await appPage.page.waitForTimeout(500);
   });
@@ -35,41 +34,41 @@ test.describe("layer management", () => {
   test("expanding layer shows layer details and buttons", async ({
     appPage,
   }) => {
-    // Click "World: Countries" collapsing header triangle at ~15px x, ~78px y
-    await appPage.clickOnCanvas(0.055, 0.108);
+    // Click "World: Countries" collapsing header
+    await appPage.clickWidget("World: Countries");
     await appPage.page.waitForTimeout(500);
     await expect(appPage.page).toHaveScreenshot("layer-details-expanded.png");
   });
 
   test("clicking Manage opens manage layer window", async ({ appPage }) => {
     // Expand the layer header
-    await appPage.clickOnCanvas(0.055, 0.108);
+    await appPage.clickWidget("World: Countries");
     await appPage.page.waitForTimeout(500);
 
-    // Click "✏ Manage" button at ~100px x, ~117px y
-    await appPage.clickOnCanvas(0.078, 0.163);
+    // Click "Manage" button
+    await appPage.clickWidget("Manage");
     await appPage.page.waitForTimeout(500);
     await expect(appPage.page).toHaveScreenshot("manage-layer-window.png");
   });
 
   test("layer visibility toggle hides the layer", async ({ appPage }) => {
     // Expand the layer header
-    await appPage.clickOnCanvas(0.055, 0.108);
+    await appPage.clickWidget("World: Countries");
     await appPage.page.waitForTimeout(500);
 
-    // Click "👁 Hide" button at ~100px x, ~159px y
-    await appPage.clickOnCanvas(0.078, 0.221);
+    // Click "Hide" button
+    await appPage.clickWidget("Toggle Visibility");
     await appPage.page.waitForTimeout(1000);
     await expect(appPage.page).toHaveScreenshot("layer-hidden.png");
   });
 
   test("zoom to extent centers the map on the layer", async ({ appPage }) => {
     // Expand the layer header
-    await appPage.clickOnCanvas(0.055, 0.108);
+    await appPage.clickWidget("World: Countries");
     await appPage.page.waitForTimeout(500);
 
-    // Click "🔎 Zoom to extent" button at ~100px x, ~180px y
-    await appPage.clickOnCanvas(0.078, 0.250);
+    // Click "Zoom to extent" button
+    await appPage.clickWidget("Zoom to extent");
     await appPage.page.waitForTimeout(1000);
     await expect(appPage.page).toHaveScreenshot("zoom-to-extent.png");
   });
@@ -78,11 +77,11 @@ test.describe("layer management", () => {
     appPage,
   }) => {
     // Expand the layer header
-    await appPage.clickOnCanvas(0.055, 0.108);
+    await appPage.clickWidget("World: Countries");
     await appPage.page.waitForTimeout(500);
 
-    // Click "⚙ Operations" collapsing header at ~80px x, ~222px y
-    await appPage.clickOnCanvas(0.055, 0.308);
+    // Click "Operations" collapsing header
+    await appPage.clickWidget("Operations");
     await appPage.page.waitForTimeout(500);
     await expect(appPage.page).toHaveScreenshot("operations-expanded.png");
   });

--- a/www/tests/side-panel.spec.ts
+++ b/www/tests/side-panel.spec.ts
@@ -11,12 +11,12 @@ test.describe("side panel - layers panel", () => {
     appPage,
   }) => {
     // First close the Add Layer window that opens by default
-    // Click its X button at ~284px x, ~55px y
+    // Click its X button
     await appPage.clickOnCanvas(0.222, 0.076);
     await appPage.page.waitForTimeout(500);
 
-    // Now click the "+ Add Layer" button at ~100px x, ~57px y
-    await appPage.clickOnCanvas(0.078, 0.079);
+    // Now click the "Add Layer" button
+    await appPage.clickWidget("Add Layer");
     await appPage.page.waitForTimeout(500);
     await expect(appPage.page).toHaveScreenshot(
       "add-layer-window-from-button.png",

--- a/www/tests/smoke.spec.ts
+++ b/www/tests/smoke.spec.ts
@@ -59,8 +59,7 @@ test("clicking Library option changes the view", async ({ appPage }) => {
   const before = await appPage.page.screenshot();
 
   // Click the "Library" radio button in the Add Layer panel
-  // Located at approximately (190, 105) in the 1280x720 viewport
-  await appPage.clickOnCanvas(0.148, 0.146);
+  await appPage.clickWidget("Library");
 
   const after = await appPage.page.screenshot();
   expect(Buffer.compare(before, after)).not.toBe(0);
@@ -72,14 +71,14 @@ test("add World Countries layer from library", async ({ appPage }) => {
   test.setTimeout(60000);
 
   // Click the "Library" radio button
-  await appPage.clickOnCanvas(0.148, 0.146);
+  await appPage.clickWidget("Library");
 
-  // Expand the "World" folder (click the ► arrow)
-  await appPage.clickOnCanvas(0.137, 0.424);
+  // Expand the "World" folder
+  await appPage.clickWidget("World");
   await appPage.page.waitForTimeout(500);
 
   // Click the "+ Add" button next to "Countries"
-  await appPage.clickOnCanvas(0.162, 0.454);
+  await appPage.clickWidget("Add:Countries");
 
   // Wait for the layer to load from network and render
   await appPage.page.waitForTimeout(10000);

--- a/www/tests/text-layer-input.spec.ts
+++ b/www/tests/text-layer-input.spec.ts
@@ -2,8 +2,7 @@ import { test, expect } from "./fixtures/app-fixture";
 
 test.describe("text layer input", () => {
   test("selecting Text source shows format options", async ({ appPage }) => {
-    // Click "Text" radio button at ~170px x, ~147px y
-    await appPage.clickOnCanvas(0.133, 0.204);
+    await appPage.clickWidget("Text");
     await appPage.page.waitForTimeout(500);
     await expect(appPage.page).toHaveScreenshot("text-tab-selected.png");
   });
@@ -11,12 +10,10 @@ test.describe("text layer input", () => {
   test("selecting GeoJSON format in text tab shows text area", async ({
     appPage,
   }) => {
-    // Click "Text" radio
-    await appPage.clickOnCanvas(0.133, 0.204);
+    await appPage.clickWidget("Text");
     await appPage.page.waitForTimeout(500);
 
-    // Select GeoJSON format - first radio under format section
-    await appPage.clickOnCanvas(0.133, 0.26);
+    await appPage.clickWidget("GeoJSON");
     await appPage.page.waitForTimeout(500);
     await expect(appPage.page).toHaveScreenshot(
       "text-tab-geojson-textarea.png",
@@ -26,12 +23,10 @@ test.describe("text layer input", () => {
   test("selecting WKT format in text tab shows WKT hint", async ({
     appPage,
   }) => {
-    // Click "Text" radio
-    await appPage.clickOnCanvas(0.133, 0.204);
+    await appPage.clickWidget("Text");
     await appPage.page.waitForTimeout(500);
 
-    // Select WKT format - third radio under format section
-    await appPage.clickOnCanvas(0.133, 0.30);
+    await appPage.clickWidget("WKT");
     await appPage.page.waitForTimeout(500);
     await expect(appPage.page).toHaveScreenshot("text-tab-wkt-textarea.png");
   });

--- a/www/tests/top-panel.spec.ts
+++ b/www/tests/top-panel.spec.ts
@@ -6,22 +6,19 @@ test.describe("top panel - menu bar", () => {
   });
 
   test("File menu opens", async ({ appPage }) => {
-    // "File" is at ~40px from left, ~11px from top in 1280x720
-    await appPage.clickOnCanvas(0.031, 0.015);
+    await appPage.clickWidget("File");
     await appPage.page.waitForTimeout(500);
     await expect(appPage.page).toHaveScreenshot("file-menu-open.png");
   });
 
   test("View menu opens", async ({ appPage }) => {
-    // "View" is at ~78px from left
-    await appPage.clickOnCanvas(0.061, 0.015);
+    await appPage.clickWidget("View");
     await appPage.page.waitForTimeout(500);
     await expect(appPage.page).toHaveScreenshot("view-menu-open.png");
   });
 
   test("Help menu opens", async ({ appPage }) => {
-    // "Help" is at ~120px from left
-    await appPage.clickOnCanvas(0.094, 0.015);
+    await appPage.clickWidget("Help");
     await appPage.page.waitForTimeout(500);
     await expect(appPage.page).toHaveScreenshot("help-menu-open.png");
   });
@@ -33,15 +30,13 @@ test.describe("top panel - tool buttons", () => {
   });
 
   test("clicking Query Tool switches active tool", async ({ appPage }) => {
-    // "Query Tool" is at ~280px from left
-    await appPage.clickOnCanvas(0.219, 0.015);
+    await appPage.clickWidget("Query Tool");
     await appPage.page.waitForTimeout(500);
     await expect(appPage.page).toHaveScreenshot("query-tool-selected.png");
   });
 
   test("clicking Measure Tool switches active tool", async ({ appPage }) => {
-    // "Measure Tool" is at ~380px from left
-    await appPage.clickOnCanvas(0.297, 0.015);
+    await appPage.clickWidget("Measure Tool");
     await appPage.page.waitForTimeout(500);
     await expect(appPage.page).toHaveScreenshot("measure-tool-selected.png");
   });

--- a/www/tests/welcome-window.spec.ts
+++ b/www/tests/welcome-window.spec.ts
@@ -6,8 +6,7 @@ test.describe("welcome window", () => {
   });
 
   test("welcome window can be closed", async ({ appPage }) => {
-    // Close welcome window by clicking its X button
-    // X is at top-right of welcome window: ~778px x, ~340px y in 1280x720
+    // Close welcome window by clicking its X button (egui internal)
     await appPage.clickOnCanvas(0.608, 0.472);
     await appPage.page.waitForTimeout(500);
     await expect(appPage.page).toHaveScreenshot("welcome-window-closed.png");


### PR DESCRIPTION
## Summary
- Adds a widget position bridge that exports egui widget screen rects from WASM via `wasm-bindgen`, so Playwright tests can click by label instead of fragile hardcoded coordinates
- Introduces a thread-local widget registry in `rgis-ui` (no-op on native builds) and instruments ~20 key UI widgets
- Adds `clickWidget(label)` / `listWidgets()` helpers to the Playwright fixture and migrates ~40 `clickOnCanvas` calls across all 10 spec files

## Test plan
- [ ] `cargo check` passes (verified locally)
- [ ] WASM build succeeds in CI
- [ ] All Playwright tests pass with the new `clickWidget` approach
- [ ] `listWidgets()` returns correct widget positions at runtime