### PR TITLE
Integrate bevy_picking for map feature selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,6 +1037,7 @@ dependencies = [
  "bevy_ecs",
  "bevy_input",
  "bevy_math",
+ "bevy_picking",
  "bevy_reflect",
  "bevy_window",
  "log",
@@ -1064,10 +1065,12 @@ dependencies = [
  "bevy_gizmos_render",
  "bevy_image",
  "bevy_input",
+ "bevy_input_focus",
  "bevy_log",
  "bevy_math",
  "bevy_mesh",
  "bevy_pbr",
+ "bevy_picking",
  "bevy_platform",
  "bevy_ptr",
  "bevy_reflect",
@@ -5238,7 +5241,6 @@ dependencies = [
  "geo-projected",
  "rgis-crs",
  "rgis-layer-events",
- "rgis-map-events",
  "rgis-primitives",
  "rgis-renderer-events",
  "rgis-ui-events",
@@ -5254,7 +5256,6 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "geo-features",
- "geo-projected",
  "rgis-primitives",
 ]
 
@@ -5268,7 +5269,6 @@ dependencies = [
  "geo-projected",
  "num-t",
  "rgis-camera-events",
- "rgis-map-events",
  "rgis-settings",
  "rgis-units",
 ]
@@ -5286,17 +5286,21 @@ name = "rgis-renderer"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "bevy_egui",
  "bevy_jobs",
  "geo",
  "geo-bevy",
  "geo-geom-type",
  "geo-projected",
+ "num-t",
  "rgis-crs-events",
  "rgis-layer-events",
  "rgis-layers",
  "rgis-map-events",
  "rgis-primitives",
  "rgis-renderer-events",
+ "rgis-settings",
+ "rgis-ui-events",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ bevy = { version = "0.18", default-features = false, features = [
     "bevy_sprite",
     "bevy_sprite_render",
     "bevy_ui",
+    "bevy_picking",
     "wayland",
     "png",
 ] }

--- a/rgis-layers/Cargo.toml
+++ b/rgis-layers/Cargo.toml
@@ -17,7 +17,6 @@ geo-projected = { path = "../geo-projected" }
 rgis-layer-events = { path = "../rgis-layer-events" }
 rgis-renderer-events = { path = "../rgis-renderer-events" }
 rgis-ui-events = { path = "../rgis-ui-events" }
-rgis-map-events = { path = "../rgis-map-events" }
 rgis-primitives = { path = "../rgis-primitives" }
 geo = { workspace = true }
 rgis-crs = { path = "../rgis-crs" }

--- a/rgis-layers/src/systems.rs
+++ b/rgis-layers/src/systems.rs
@@ -124,24 +124,6 @@ fn handle_move_layer_events(
     }
 }
 
-fn handle_map_clicked_events(
-    mut map_clicked_event_reader: MessageReader<rgis_map_events::MapClickedEvent>,
-    mut render_message_event_writer: MessageWriter<rgis_ui_events::RenderFeaturePropertiesEvent>,
-    mut feature_clicked_event_writer: MessageWriter<rgis_map_events::FeatureSelectedEvent>,
-    layers: Res<crate::Layers>,
-) {
-    for event in map_clicked_event_reader.read() {
-        if let Some((layer, feature)) = layers.feature_from_click(event.0) {
-            render_message_event_writer.write(rgis_ui_events::RenderFeaturePropertiesEvent {
-                layer_id: layer.id,
-                properties: feature.properties.clone(),
-            });
-            feature_clicked_event_writer
-                .write(rgis_map_events::FeatureSelectedEvent(layer.id, feature.id));
-        }
-    }
-}
-
 fn handle_create_layer_events(
     mut create_layer_events: ResMut<Messages<rgis_layer_events::CreateLayerEvent>>,
     mut layer_created_event_writer: MessageWriter<rgis_layer_events::LayerCreatedEvent>,
@@ -181,7 +163,6 @@ pub fn configure(app: &mut App) {
             handle_update_point_size_events,
             handle_move_layer_events,
             handle_delete_layer_events,
-            handle_map_clicked_events,
             handle_create_layer_events,
             handle_duplicate_layer_events,
         ),

--- a/rgis-map-events/Cargo.toml
+++ b/rgis-map-events/Cargo.toml
@@ -5,6 +5,5 @@ edition = "2021"
 
 [dependencies]
 bevy = { workspace = true }
-geo-projected = { path = "../geo-projected" }
 rgis-primitives = { path = "../rgis-primitives" }
 geo-features = { path = "../geo-features" }

--- a/rgis-map-events/src/lib.rs
+++ b/rgis-map-events/src/lib.rs
@@ -1,8 +1,4 @@
 use bevy::prelude::*;
-use geo_projected::ProjectedCoord;
-
-#[derive(Message)]
-pub struct MapClickedEvent(pub ProjectedCoord);
 
 #[derive(Clone, Copy, Message, Debug)]
 pub struct FeatureSelectedEvent(pub rgis_primitives::LayerId, pub geo_features::FeatureId);
@@ -14,8 +10,7 @@ pub struct Plugin;
 
 impl bevy::app::Plugin for Plugin {
     fn build(&self, app: &mut App) {
-        app.add_message::<MapClickedEvent>()
-            .add_message::<FeatureSelectedEvent>()
+        app.add_message::<FeatureSelectedEvent>()
             .add_message::<FeaturesDeselectedEvent>();
     }
 }

--- a/rgis-mouse/Cargo.toml
+++ b/rgis-mouse/Cargo.toml
@@ -14,7 +14,6 @@ bevy_egui = { workspace = true }
 geo = { workspace = true }
 geo-projected = { path = "../geo-projected" }
 rgis-camera-events = { path = "../rgis-camera-events" }
-rgis-map-events = { path = "../rgis-map-events" }
 rgis-settings = { path = "../rgis-settings" }
 rgis-units = { path = "../rgis-units" }
 num-t = { workspace = true }

--- a/rgis-mouse/src/systems.rs
+++ b/rgis-mouse/src/systems.rs
@@ -123,19 +123,8 @@ fn run_if_mouse_left_button_just_pressed(mouse_button: Res<ButtonInput<MouseButt
     mouse_button.just_pressed(MouseButton::Left)
 }
 
-fn current_tool_is_query(rgis_settings: Res<rgis_settings::RgisSettings>) -> bool {
-    rgis_settings.current_tool == rgis_settings::Tool::Query
-}
-
 fn current_tool_is_measure(rgis_settings: Res<rgis_settings::RgisSettings>) -> bool {
     rgis_settings.current_tool == rgis_settings::Tool::Measure
-}
-
-fn mouse_click_system(
-    mut map_clicked_event_writer: MessageWriter<rgis_map_events::MapClickedEvent>,
-    mouse_position: Res<crate::MousePos>,
-) {
-    map_clicked_event_writer.write(rgis_map_events::MapClickedEvent(mouse_position.0));
 }
 
 fn measure_click_system(
@@ -221,9 +210,6 @@ pub fn configure(app: &mut App) {
             cursor_moved_system.run_if(run_if_has_cursor_moved_events),
             recalculate_mouse_position_system.run_if(run_if_has_recalculate_mouse_position_events),
             mouse_scroll_system.run_if(run_if_has_mouse_scroll_events),
-            mouse_click_system
-                .run_if(current_tool_is_query)
-                .run_if(run_if_mouse_left_button_just_pressed),
             measure_click_system
                 .run_if(current_tool_is_measure)
                 .run_if(run_if_mouse_left_button_just_pressed),

--- a/rgis-renderer/Cargo.toml
+++ b/rgis-renderer/Cargo.toml
@@ -18,4 +18,8 @@ rgis-crs-events = { path = "../rgis-crs-events" }
 rgis-map-events = { path = "../rgis-map-events" }
 rgis-primitives = { path = "../rgis-primitives" }
 rgis-layers = { path = "../rgis-layers" }
+rgis-settings = { path = "../rgis-settings" }
+rgis-ui-events = { path = "../rgis-ui-events" }
+bevy_egui = { workspace = true }
 bevy_jobs = { workspace = true }
+num-t = { workspace = true }

--- a/rgis-renderer/src/systems.rs
+++ b/rgis-renderer/src/systems.rs
@@ -2,6 +2,53 @@ use bevy::prelude::*;
 
 use crate::{jobs::MeshBuildingJob, RenderEntityType};
 
+fn handle_picking_click(
+    on: On<Pointer<Click>>,
+    layer_query: Query<
+        &rgis_primitives::LayerId,
+        Or<(With<crate::Point>, With<crate::Polygon>, With<crate::LineString>)>,
+    >,
+    layers: Res<rgis_layers::Layers>,
+    settings: Res<rgis_settings::RgisSettings>,
+    mut bevy_egui_ctx: bevy_egui::EguiContexts,
+    mut feature_selected_writer: MessageWriter<rgis_map_events::FeatureSelectedEvent>,
+    mut render_props_writer: MessageWriter<rgis_ui_events::RenderFeaturePropertiesEvent>,
+) {
+    if settings.current_tool != rgis_settings::Tool::Query {
+        return;
+    }
+
+    if let Ok(ctx) = bevy_egui_ctx.ctx_mut() {
+        if ctx.is_pointer_over_area() {
+            return;
+        }
+    }
+
+    // Only handle on parent entities (which have LayerId + geometry marker)
+    let Ok(_layer_id) = layer_query.get(on.event_target()) else {
+        return;
+    };
+
+    // Get the hit position in world space (== projected coordinates)
+    let Some(hit_position) = on.event().event.hit.position else {
+        return;
+    };
+
+    let coord = geo::Coord {
+        x: num_t::Num::new(f64::from(hit_position.x)),
+        y: num_t::Num::new(f64::from(hit_position.y)),
+    };
+
+    if let Some((layer, feature)) = layers.feature_from_click(coord) {
+        render_props_writer.write(rgis_ui_events::RenderFeaturePropertiesEvent {
+            layer_id: layer.id,
+            properties: feature.properties.clone(),
+        });
+        feature_selected_writer
+            .write(rgis_map_events::FeatureSelectedEvent(layer.id, feature.id));
+    }
+}
+
 fn layer_loaded(
     layers: Res<rgis_layers::Layers>,
     mut event_reader: MessageReader<rgis_layer_events::LayerReprojectedEvent>,
@@ -341,4 +388,5 @@ pub fn configure(app: &mut App) {
             handle_feature_selected_event_spawn,
         ),
     );
+    app.add_observer(handle_picking_click);
 }

--- a/rgis/src/lib.rs
+++ b/rgis/src/lib.rs
@@ -1,3 +1,4 @@
+use bevy::picking::mesh_picking::MeshPickingPlugin;
 use bevy::prelude::*;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
@@ -49,6 +50,7 @@ pub fn run() {
             .disable::<bevy::log::LogPlugin>(),
     );
     app.add_plugins(bevy::log::LogPlugin::default());
+    app.add_plugins(MeshPickingPlugin);
     app.add_plugins(rgis_ui::Plugin);
     app.add_plugins(rgis_layers::Plugin);
     app.add_plugins(rgis_file_loader::Plugin);


### PR DESCRIPTION
## Summary
- Enable `bevy_picking` feature and add `MeshPickingPlugin` for built-in mesh/sprite hit detection
- Add a global `Pointer<Click>` observer in `rgis-renderer` that checks the Query tool is active, converts hit position to projected coordinates, and uses existing `feature_from_click()` to identify and select features
- Remove the old manual click pipeline (`MapClickedEvent`, `mouse_click_system`, `handle_map_clicked_events`)

Supersedes #138.

## Test plan
- [ ] `cargo check` passes
- [ ] Load a layer, select Query tool, click a feature → should highlight + show properties
- [ ] Clicking on egui UI panels should not trigger feature selection
- [ ] Pan and Measure tools should not trigger picking behavior