### PR TITLE
Fix progress bar exceeding 100% during WASM loading

### DIFF
--- a/www/index.js
+++ b/www/index.js
@@ -16,7 +16,7 @@ async function fetchWasmWithProgress() {
         chunks.push(value);
         received += value.length;
         if (total) {
-            const pct = Math.round((received / total) * 100);
+            const pct = Math.min(100, Math.round((received / total) * 100));
             bar.style.width = pct + "%";
             text.textContent = pct + "%";
         } else {


### PR DESCRIPTION
## Summary
- `Content-Length` reflects the **compressed** wire size, but `response.body.getReader()` delivers **decompressed** chunks, so `received` can exceed `total` when the server uses gzip/brotli compression
- Cap the percentage at 100 with `Math.min()` to prevent the bar from overflowing

## Test plan
- [ ] Deploy with a server that compresses `.wasm` files and verify the progress bar stays at or below 100%