### PR TITLE
Point bevy_egui at main branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,7 +1034,7 @@ dependencies = [
 [[package]]
 name = "bevy_egui"
 version = "0.39.1"
-source = "git+https://github.com/frewsxcv/bevy_egui?branch=integrate-egui-wgpu#611f4831207678c81176fc22f1923b86b39d9b43"
+source = "git+https://github.com/frewsxcv/bevy_egui?branch=main#2b64204e91ce35efc1044f4049267cfa3734d65f"
 dependencies = [
  "arboard",
  "bevy_app",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ bevy = { version = "0.18", default-features = false, features = [
     "wayland",
     "png",
 ] }
-bevy_egui = { git = "https://github.com/frewsxcv/bevy_egui", branch = "integrate-egui-wgpu" }
+bevy_egui = { git = "https://github.com/frewsxcv/bevy_egui", branch = "main" }
 bevy_jobs = { git = "https://github.com/frewsxcv/bevy_jobs", rev = "7b412d4ea7f0b7ed65ed7c4e3c8145d59c0df03e" }
 bevy_jobs_fetch = { git = "https://github.com/frewsxcv/bevy_jobs", rev = "7b412d4ea7f0b7ed65ed7c4e3c8145d59c0df03e" }
 bevy_log = "0.18"


### PR DESCRIPTION
The integrate-egui-wgpu work has landed on main, so track main directly instead of the feature branch.